### PR TITLE
Fix and clean up export and import

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -57,7 +57,7 @@ Looking for other types of directories? Check out [Business Directory Plugin](ht
 * Multiple fee scales for posting ads (allows you to have longer ad postings with higher fees)
 * Variable ad expiration lengths connected to fee scale (e.g. allow ads to run for 30 days for $10, 60 days for $15, etc)
 * Supports a "credit system" or pay with regular currency per ad. Mix and match if you want.
-* Support for ad "subscriptions" (packages of ads for a single price)
+* Support for ad memberships (packages of ads for a single price)
 
 == Posting Controls for your WordPress classified ads  ==
 
@@ -90,7 +90,7 @@ Looking for other types of directories? Check out [Business Directory Plugin](ht
 * [Featured Ads](https://awpcp.com/downloads/featured-ads-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allows you to promote certain ads over others by charging a fee for them, featured ads are displayed using CSS to highlight them. Featured ads are always returned first in a category, the overall ad list, or in search results. Also has a widget for placement anywhere on your site. Full admin control of featured ads, too
 * [BuddyPress](https://awpcp.com/downloads/buddypress-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allows users to manage their listing ads in the BuddyPress profile directly, see events from ad posting in the activity stream and more
 * [Fee per Category](https://awpcp.com/downloads/fee-per-category-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allows you to charge for certain categories and not others, giving you more freedom on how to configure your classified section. Allows for multiple fee plans per category, as well as a default plan to cover "all other unspecified" categories
-* [Subscriptions](https://awpcp.com/downloads/subscriptions-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allows power users to place blocks of ads at a time, great for real estate agents, car dealers, anyone who wants to place ads in bulk
+* [Membership to Post](https://awpcp.com/downloads/subscriptions-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allows power users to place blocks of ads at a time, great for real estate agents, car dealers, anyone who wants to place ads in bulk
 * [Comments/Ratings](https://awpcp.com/downloads/comments-ratings-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allow users to rate classified ads, and add ratings and comments on listings
 * [RSS Feeds](https://awpcp.com/downloads/rss-feeds-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allows you syndicate your ads for your users to download in their favorite RSS reader and come back to your site more often!
 * [Coupons/Discounts](https://awpcp.com/downloads/coupons-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allows you to offer coupon codes for ad promotions to your users, coupons can be a percent off, or a fixed amount, have expiration dates and be tracked by usage
@@ -106,7 +106,7 @@ Want to accept credit cards on your site for paid listings in your classifieds d
 
 * [Stripe](https://awpcp.com/downloads/stripe-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - accept payments via Stripe for ads
 * [PayPal Pro]( https://awpcp.com/downloads/paypal-pro-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allows you to have an embedded payment form on your site for use with PayPal Pro accounts
-* [Authorize.net Gateway](https://awpcp.com/downloads/authorizenet-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allows users to purchase ads, subscriptions and credit plans using Authorize.net
+* [Authorize.net Gateway](https://awpcp.com/downloads/authorizenet-module/?utm_source=wprepo&utm_medium=link&utm_campaign=liteversion) - allows users to purchase ads and credit plans using Authorize.net
 
 These are just some of the features of our easy WordPress Classifieds Plugin.
 

--- a/admin/class-csv-exporter.php
+++ b/admin/class-csv-exporter.php
@@ -264,8 +264,16 @@ class AWPCP_CSVExporter {
         $out     = '';
         $columns = $this->columns;
         foreach ( $columns as $colname => &$col ) {
-            $out .= $colname;
-            $out .= $this->settings['csv-file-separator'];
+			if ( empty( $col['name'] ) ) {
+				// These labels are nested, so go another level.
+				foreach ( $col as $colname2 => &$col2 ) {
+					$out .= $colname2;
+					$out .= $this->settings['csv-file-separator'];
+				}
+			} else {
+				$out .= $colname;
+				$out .= $this->settings['csv-file-separator'];
+			}
         }
 
         $out = substr( $out, 0, - 1 );
@@ -323,8 +331,9 @@ class AWPCP_CSVExporter {
         $value = get_post_meta( $this->listing->ID, $column['name'], true );
 
         if ( $column['name'] === '_awpcp_start_date' || $column['name'] === '_awpcp_end_date' ) {
-            $value = date_create( $value );
-            $value = date_format( $value, 'm/d/y H:i:s' );
+			$value = date_create( $value );
+			$format = apply_filters( 'awpcp_export_date_format', 'Y-m-d H:i:s' );
+			$value = date_format( $value, $format );
         }
 
         if ( $column['name'] === '_awpcp_sequence_id' ) {

--- a/admin/class-import-listings-admin-page.php
+++ b/admin/class-import-listings-admin-page.php
@@ -283,7 +283,6 @@ class AWPCP_ImportListingsAdminPage {
 
         $import_session->set_params( array(
             'date_format' => $this->request->post( 'date_format' ),
-            'date_separator' => $this->request->post( 'date_separator' ),
             'category_separator' => $this->request->post( 'category_separator' ),
             'time_separator' => $this->request->post( 'time_separator' ),
             'images_separator' => $this->request->post( 'images_separator' ),
@@ -316,10 +315,10 @@ class AWPCP_ImportListingsAdminPage {
                 'define_default_dates' => $define_default_dates,
                 'default_start_date' => '',
                 'default_end_date' => '',
-                'date_format' => 'us_date',
+                'date_format'          => 'auto',
                 'listing_status' => 'default',
                 'time_separator' => ':',
-                'date_separator' => '/',
+                'date_separator' => '/', // For reverse compatibility with custom template.
                 'category_separator' => ';',
                 'images_separator' => ';',
                 'create_missing_categories' => false,

--- a/admin/templates/admin-sidebar.tpl.php
+++ b/admin/templates/admin-sidebar.tpl.php
@@ -33,7 +33,7 @@
                         'span_attributes'    => array(
                             'class' => 'red',
                         ),
-                        'content'            => '<strong>' . __( 'Get a Premium Module!', 'another-wordpress-classifieds-plugin' ) . '</strong>',
+                        'content'            => '<strong>' . __( 'Get more features!', 'another-wordpress-classifieds-plugin' ) . '</strong>',
                     );
                     // phpcs:ignore WordPress.Security.EscapeOutput
                     echo awpcp_html_postbox_handle( $params );

--- a/functions.php
+++ b/functions.php
@@ -240,6 +240,7 @@ function awpcp_strip_all_tags_deep( $string ) {
 
 /**
  * @since 3.0.2
+ * @todo Check if add-ons use this and deprecate.
  */
 function awpcp_strptime( $date, $format ) {
 	if ( function_exists( 'strptime' ) ) {

--- a/includes/class-awpcp.php
+++ b/includes/class-awpcp.php
@@ -877,7 +877,7 @@ class AWPCP {
                     'required' => '4.0.0',
                 ),
                 'subscriptions' => array(
-                    'name' => __( 'Subscriptions', 'another-wordpress-classifieds-plugin' ),
+                    'name' => __( 'Membership to Post', 'another-wordpress-classifieds-plugin' ),
                     'url' => 'https://awpcp.com/downloads/subscriptions-module/?ref=panel',
                     'installed' => defined( 'AWPCP_SUBSCRIPTIONS_MODULE' ),
                     'version' => 'AWPCP_SUBSCRIPTIONS_MODULE_DB_VERSION',

--- a/templates/admin/import-listings-admin-page-configuration-form.tpl.php
+++ b/templates/admin/import-listings-admin-page-configuration-form.tpl.php
@@ -54,30 +54,18 @@
                             </th>
                             <td>
                                 <?php echo awpcp_form_error( 'date_format', $form_errors ); ?>
-                                <input id="awpcp-importer-format-us-date" type="radio" name="date_format" value="us_date"<?php echo $form_data['date_format'] == 'us_date' ? ' checked="checked"' : ''; ?>/>
-                                <label for="awpcp-importer-format-us-date">
-                                    <?php echo esc_html( __( 'US Date Only (mm/dd/year)', 'another-wordpress-classifieds-plugin' ) ); ?></label>
-                                <br/>
 
-                                <input id="awpcp-importer-format-uk-date" type="radio" name="date_format" value="uk_date"<?php echo $form_data['date_format'] == 'uk_date' ? ' checked="checked"' : ''; ?>/>
-                                <label for="awpcp-importer-format-uk-date"><?php echo esc_html( __( 'UK Date Only (dd/mm/year)', 'another-wordpress-classifieds-plugin' ) ); ?></label>
-                                <br/>
-
-                                <input id="awpcp-importer-format-eur-date" type="radio" name="date_format" value="eur_date" <?php echo $form_data['date_format'] == "eur_date" ? 'checked:="checked"' : ''; ?> />
-                                <label for="awpcp-importer-format-eur-date"><?php echo esc_html( __( 'EUR Date Only (year/mm/dd)', 'another-wordpress-classifieds-plugin' ) ); ?></label>
-                                <br/>
-
-                                <input id="awpcp-importer-format-us-date-time" type="radio" name="date_format" value="us_date_time"<?php echo $form_data['date_format'] == 'us_date_time' ? ' checked="checked"' : ''; ?>/>
-                                <label for="awpcp-importer-format-us-date-time">
-                                    <?php echo esc_html( __( 'US Date and Time (mm/dd/year hh:mm:ss)', 'another-wordpress-classifieds-plugin' ) ); ?></label>
-                                <br/>
-
-                                <input id="awpcp-importer-format-uk-date-time" type="radio" name="date_format" value="uk_date_time" <?php echo $form_data['date_format'] == "uk_date_time" ? 'checked:="checked"' : ''; ?> />
-                                <label for="awpcp-importer-format-uk-date-time"><?php echo esc_html( __( 'UK Date and Time (dd/mm/year hh:mm:ss)', 'another-wordpress-classifieds-plugin' ) ); ?></label>
-                                <br />
-
-                                <input id="awpcp-importer-format-eur-date-time" type="radio" name="date_format" value="eur_date_time" <?php echo $form_data['date_format'] == "eur_date_time" ? 'checked:="checked"' : ''; ?> />
-                                <label for="awpcp-importer-format-eur-date-time"><?php echo esc_html( __( 'EUR Date and Time (year/mm/dd hh:mm:ss)', 'another-wordpress-classifieds-plugin' ) ); ?></label>
+								<select name="date_format" id="awpcp-importer-format">
+									<option value="auto">
+										<?php esc_html_e( 'Automatic', 'another-wordpress-classifieds-plugin' ); ?>
+									</option>
+									<option value="uk_date" <?php selected( $form_data['date_format'], 'uk_date' ); ?>>
+										<?php esc_html_e( 'UK (dd/mm/year)', 'another-wordpress-classifieds-plugin' ); ?>
+									</option>
+									<option value="eur_date" <?php selected( $form_data['date_format'], 'eur_date' ); ?>>
+										<?php esc_html_e( 'EUR (year/mm/dd)', 'another-wordpress-classifieds-plugin' ); ?>
+									</option>
+								</select>
                             </td>
                         </tr>
                         <tr class="csv-separators">
@@ -85,13 +73,6 @@
                                 <?php echo esc_html( __( 'Separators Used in CSV', 'another-wordpress-classifieds-plugin' ) ); ?>
                             </th>
                             <td>
-                                <p>
-                                    <label for="awpcp-importer-date-separator"><?php echo esc_html( __( 'Date Separator', 'another-wordpress-classifieds-plugin' ) ); ?></label>
-                                    <input id="awpcp-importer-date-separator" type="text" maxlength="1" size="1" name="date_separator"
-                                           value="<?php echo esc_attr( $form_data['date_separator'] ); ?>"/>
-                                    <?php echo awpcp_form_error( 'date_separator', $form_errors ); ?>
-                                </p>
-
 
                                 <p><label for="awpcp-importer-time-separator"><?php echo esc_html( __( 'Time Separator', 'another-wordpress-classifieds-plugin' ) ); ?></label>
                                     <input id="awpcp-importer-time-separator" type="text" maxlength="1" size="1" name="time_separator"

--- a/tests/suite/admin/import/test-csv-importer-delegate.php
+++ b/tests/suite/admin/import/test-csv-importer-delegate.php
@@ -80,7 +80,6 @@ class AWPCP_Test_CSV_Importer_Delegate extends AWPCP_UnitTestCase {
         Phake::when( $this->import_session )->is_test_mode_enabled->thenReturn( false );
         Phake::when( $this->import_session )->get_param( 'create_missing_categories' )->thenReturn( true );
         Phake::when( $this->import_session )->get_param( 'date_format' )->thenReturn( 'us_date' );
-        Phake::when( $this->import_session )->get_param( 'date_separator' )->thenReturn( '/' );
         Phake::when( $this->import_session )->get_param( 'time_separator' )->thenReturn( ':' );
         Phake::when( $this->import_session )->get_param( 'category_separator' )->thenReturn( ';' );
 

--- a/tests/suite/templates/test-templates.php
+++ b/tests/suite/templates/test-templates.php
@@ -121,7 +121,6 @@ class AWPCP_TestTemplates extends AWPCP_UnitTestCase {
                 'default_end_date' => null,
                 'date_format' => null,
                 'time_separator' => null,
-                'date_separator' => null,
                 'images_separator' => null,
                 'create_missing_categories' => null,
                 'assign_listings_to_user' => null,


### PR DESCRIPTION
- Fix missing column names in export https://github.com/Strategy11/awpcp/issues/3098
- Simplify the import to handle dates easier with fewer settings (Removed separate date formats with hours, removed the date separator option).
- Add awpcp_export_date_format hook for date format in export
- Change the default export date format from m/d/y to Y-m-d

I tested this quite a bit, but one more look over would be nice. I'm not able to export and then import again without any settings changes.

Since the date conversions were changed a lot to remove a bunch of extra code, it would be good to test those a bit too. American formats shouldn't be a problem, but I could use another look at this for UK and European formats. This should be able to handle these formats without the need for the date separator setting.