### PR TITLE
Deleting expired ads

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -98,6 +98,7 @@ function doadcleanup() {
  */
 function awpcp_delete_listings_expired_more_than_days_ago( $number_of_days, $listings_logic, $listings ) {
     $date_query = new WP_Date_Query( [] );
+    $end_date   = $date_query->build_mysql_datetime( sprintf( '%d days ago', $number_of_days ) );
 
     $query_vars = [
         'post_status' => 'disabled',
@@ -107,13 +108,13 @@ function awpcp_delete_listings_expired_more_than_days_ago( $number_of_days, $lis
                 [
                     'key'     => '_awpcp_disabled_date',
                     'compare' => '<',
-                    'value'   => $date_query->build_mysql_datetime( sprintf( '%d days ago', $number_of_days ) ),
+                    'value'   => $end_date,
                     'type'    => 'DATE',
                 ],
                 [
                     'key'     => '_awpcp_end_date',
                     'compare' => '<',
-                    'value'   => $date_query->build_mysql_datetime( sprintf( '%d days ago', $number_of_days ) ),
+                    'value'   => $end_date,
                     'type'    => 'DATE',
                 ],
             ],

--- a/cron.php
+++ b/cron.php
@@ -27,29 +27,6 @@ function awpcp_schedule_activation() {
     add_action('awpcp-clean-up-payment-transactions', 'awpcp_clean_up_payment_transactions');
     add_action( 'awpcp-clean-up-payment-transactions', 'awpcp_clean_up_non_verified_ads_handler' );
     add_action( 'awpcp-check-license-status', 'awpcp_check_license_status' );
-
-    // if ( awpcp_current_user_is_admin() ) {
-    //     wp_clear_scheduled_hook( 'doadexpirations_hook' );
-    //     wp_clear_scheduled_hook( 'doadcleanup_hook' );
-    //     wp_clear_scheduled_hook( 'awpcp_ad_renewal_email_hook' );
-    //     wp_clear_scheduled_hook( 'awpcp-clean-up-payment-transactions' );
-    //     wp_clear_scheduled_hook( 'awpcp-clean-up-non-verified-ads' );
-
-    //     wp_schedule_event( time() + 10, 'hourly', 'doadexpirations_hook' );
-    //     wp_schedule_event( time() + 10, 'daily', 'doadcleanup_hook' );
-    //     wp_schedule_event( time() + 10, 'daily', 'awpcp_ad_renewal_email_hook' );
-    //     wp_schedule_event( time() + 10, 'daily', 'awpcp-clean-up-payment-transactions' );
-    //     wp_schedule_event( time() + 10, 'daily', 'awpcp-clean-up-non-verified-ads' );
-
-    //     debugp(
-    //         'System date is: ' . date('d-m-Y H:i:s'),
-    //         'Ad Expiration: ' . date('d-m-Y H:i:s', wp_next_scheduled('doadexpirations_hook')),
-    //         'Ad Cleanup: ' . date('d-m-Y H:i:s', wp_next_scheduled('doadcleanup_hook')),
-    //         'Ad Renewal Email: ' . date('d-m-Y H:i:s', wp_next_scheduled('awpcp_ad_renewal_email_hook')),
-    //         'Payment transactions: ' . date('d-m-Y H:i:s', wp_next_scheduled('awpcp-clean-up-payment-transactions')),
-    //         'Unverified Ads: ' . date('d-m-Y H:i:s', wp_next_scheduled('awpcp-clean-up-non-verified-ads'))
-    //     );
-    // }
 }
 
 /**
@@ -126,10 +103,19 @@ function awpcp_delete_listings_expired_more_than_days_ago( $number_of_days, $lis
         'post_status' => 'disabled',
         'meta_query'  => [
             [
-                'key'     => '_awpcp_disabled_date',
-                'compare' => '<',
-                'value'   => $date_query->build_mysql_datetime( sprintf( '%d days ago', $number_of_days ) ),
-                'type'    => 'DATE',
+                'relation' => 'OR',
+                [
+                    'key'     => '_awpcp_disabled_date',
+                    'compare' => '<',
+                    'value'   => $date_query->build_mysql_datetime( sprintf( '%d days ago', $number_of_days ) ),
+                    'type'    => 'DATE',
+                ],
+                [
+                    'key'     => '_awpcp_end_date',
+                    'compare' => '<',
+                    'value'   => $date_query->build_mysql_datetime( sprintf( '%d days ago', $number_of_days ) ),
+                    'type'    => 'DATE',
+                ],
             ],
             [
                 'key'     => '_awpcp_expired',

--- a/includes/helpers/class-listing-renderer.php
+++ b/includes/helpers/class-listing-renderer.php
@@ -293,10 +293,6 @@ class AWPCP_ListingRenderer {
     }
 
     public function is_disabled( $listing ) {
-        if ( $listing->post_status === 'trash' ) {
-            return true;
-        }
-
         if ( $this->disabled_status !== $listing->post_status ) {
             return false;
         }

--- a/includes/helpers/class-listing-renderer.php
+++ b/includes/helpers/class-listing-renderer.php
@@ -293,6 +293,10 @@ class AWPCP_ListingRenderer {
     }
 
     public function is_disabled( $listing ) {
+        if ( $listing->post_status === 'trash' ) {
+            return true;
+        }
+
         if ( $this->disabled_status !== $listing->post_status ) {
             return false;
         }
@@ -352,10 +356,10 @@ class AWPCP_ListingRenderer {
      */
     public function is_expired( $listing ) {
 		$expired     = $this->has_expired( $listing );
-		$is_disabled = $this->disabled_status === $listing->post_status;
+		$is_disabled = in_array( $listing->post_status, array( $this->disabled_status, 'trash' ), true );
 
 		if ( $expired && ! $is_disabled ) {
-			// This listing has expired, but isn't marked as expired.
+            // This listing has expired, but isn't marked as expired.
 			awpcp_listings_api()->expire_listing_with_notice( $listing );
 		}
 


### PR DESCRIPTION
- Prevent trashed posts from coming back
- When deleting expired adds, check by end date instead of only the disabled date

Fixes https://github.com/Strategy11/awpcp/issues/3121
Fixes https://github.com/Strategy11/awpcp/issues/3120