### PR TITLE
Uninstall fixes

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,10 +20,10 @@ jobs:
 
     name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.3
 
       # get the PHP version
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@2.25.5
         with:
           php-version: ${{ matrix.php }}
       - name: Installing WordPress

--- a/admin/class-uninstall-admin-page.php
+++ b/admin/class-uninstall-admin-page.php
@@ -46,6 +46,12 @@ class AWPCP_UninstallAdminPage {
         $dirname = $this->settings->get_runtime_option( 'awpcp-uploads-dir' );
 
         if ( 0 === strcmp( $action, 'uninstall' ) ) {
+            // Check the wp_nonce_url.
+            $nonce = awpcp_get_var( array( 'param' => '_wpnonce' ), 'get' );
+            if ( ! wp_verify_nonce( $nonce, 'awpcp-uninstall' ) || ! awpcp_current_user_is_admin() ) {
+                wp_die( esc_html__( 'You are not authorized to perform this action.', 'another-wordpress-classifieds-plugin' ) );
+            }
+
             $this->uninstaller->uninstall();
         }
 

--- a/admin/templates/admin-panel-uninstall.tpl.php
+++ b/admin/templates/admin-panel-uninstall.tpl.php
@@ -24,8 +24,9 @@
 </ol>
 
 <p>
-    <?php $href = add_query_arg( array( 'action' => 'uninstall' ), $url ); ?>
-    <a class="button button-primary" href="<?php echo esc_url( $href ); ?>"><?php esc_html_e( 'Proceed with Uninstalling AWP Classifieds Plugin', 'another-wordpress-classifieds-plugin' ); ?></a>
+    <a class="button button-primary" href="<?php echo wp_nonce_url( add_query_arg( array( 'action' => 'uninstall' ), $url ), 'awpcp-uninstall' ); ?>">
+        <?php esc_html_e( 'Proceed with Uninstalling AWP Classifieds Plugin', 'another-wordpress-classifieds-plugin' ); ?>
+    </a>
 </p>
 
 <?php elseif ( 'uninstall' === $action ) : ?>
@@ -33,7 +34,9 @@
 <h3><?php esc_html_e( 'Almost done... one more step!', 'another-wordpress-classifieds-plugin' ); ?></h3>
 
 <p>
-    <a class="button button-primary" href="<?php echo esc_attr( admin_url( 'plugins.php?deactivate=true' ) ); ?>"><?php esc_html_e( 'Please click here to complete the uninstallation process', 'another-wordpress-classifieds-plugin' ); ?></a>
+    <a class="button button-primary" href="<?php echo esc_attr( admin_url( 'plugins.php' ) ); ?>">
+        <?php esc_html_e( 'Please click here to deactivate plugins.', 'another-wordpress-classifieds-plugin' ); ?>
+    </a>
 </p>
 
 <?php endif ?>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/awpcp/issues/3165

Without the unit tests in https://github.com/Strategy11/another-wordpress-classifieds-plugin/pull/56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependencies in the GitHub workflow for improved reliability and security.

- **New Features**
	- Enhanced security for the uninstall process of the AWP Classifieds Plugin by adding nonce verification and authorization checks.

- **Refactor**
	- Updated the admin panel's uninstall functionality for the AWP Classifieds Plugin, including URL and text modifications for clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->