### PR TITLE
Move load_text_domain to the init hook

### DIFF
--- a/awpcp.php
+++ b/awpcp.php
@@ -102,9 +102,7 @@ if ( file_exists( AWPCP_DIR . '/awpcp_category_icons_module.php' ) ) {
 /* End of legacy code. */
 
 // Load text domain in init to match the changes in WP 6.7.
-add_action( 'init', function () {
-    awpcp_load_plugin_textdomain( AWPCP_FILE );
-} );
+add_action( 'init', 'awpcp_load_plugin_textdomain' );
 
 /**
  * BuddyPress normally attaches bp_loaded to plugins_loaded with priority 10.

--- a/awpcp.php
+++ b/awpcp.php
@@ -101,6 +101,11 @@ if ( file_exists( AWPCP_DIR . '/awpcp_category_icons_module.php' ) ) {
 }
 /* End of legacy code. */
 
+// Load text domain in init to match the changes in WP 6.7.
+add_action( 'init', function () {
+    awpcp_load_plugin_textdomain( AWPCP_FILE );
+} );
+
 /**
  * BuddyPress normally attaches bp_loaded to plugins_loaded with priority 10.
  * When changing the priorities below, please make sure that modules are

--- a/functions.php
+++ b/functions.php
@@ -2597,8 +2597,8 @@ function awpcp_maybe_include_lightbox_style() {
  * @since 3.9.2     Modified to use load_plugin_textdomain() in preparation for
  *                  adding support for Language Packs.
  */
-function awpcp_load_plugin_textdomain( $__file__ ) {
-    $basename = dirname( plugin_basename( $__file__ ) );
+function awpcp_load_plugin_textdomain() {
+    $basename = dirname( plugin_basename( AWPCP_FILE ) );
 
     $locale = function_exists( 'determine_locale' ) ? determine_locale() : get_locale();
     $locale = apply_filters( 'plugin_locale', $locale, 'another-wordpress-classifieds-plugin' );

--- a/includes/class-awpcp.php
+++ b/includes/class-awpcp.php
@@ -45,8 +45,6 @@ class AWPCP {
         $this->settings_manager = $this->container['SettingsManager'];
         $this->js = AWPCP_JavaScript::instance();
 
-        awpcp_load_plugin_textdomain( AWPCP_FILE );
-
         // TODO: Fix activation hook
         // awpcp_register_activation_hook( AWPCP_FILE, array( $this->installer, 'activate' ) );
     }


### PR DESCRIPTION
fixes https://github.com/Strategy11/awpcp/issues/3179

This PR moves the load_text_domain function to the init hook to prevent a notice that was added in WordPress 6.7