### PR TITLE
Add style property to the thumbnail image element

### DIFF
--- a/frontend/class-image-placeholders.php
+++ b/frontend/class-image-placeholders.php
@@ -101,6 +101,9 @@ class AWPCP_Image_Placeholders {
                 $image_attributes = array(
                     'class' => 'awpcp-listing-primary-image-thumbnail',
                     'alt'   => awpcp_esc_attr( $this->listing_renderer->get_listing_title( $ad ) ),
+                    // This was added after WordPress 6.7
+                    // See: https://github.com/Strategy11/awpcp/issues/3178
+                    'style' => 'width: ' . $thumbnail_width . 'px;',
                 );
 
                 // TODO: Can we regeneate thumbnails every time the user changes
@@ -187,6 +190,7 @@ class AWPCP_Image_Placeholders {
                     'alt' => awpcp_esc_attr( $this->listing_renderer->get_listing_title( $ad ) ),
                     'src' => esc_attr( $thumbnail ),
                     'width' => esc_attr( $thumbnail_width ),
+                    'style' => 'width: 80px !important;',
                 ),
             );
 

--- a/frontend/class-image-placeholders.php
+++ b/frontend/class-image-placeholders.php
@@ -190,7 +190,6 @@ class AWPCP_Image_Placeholders {
                     'alt' => awpcp_esc_attr( $this->listing_renderer->get_listing_title( $ad ) ),
                     'src' => esc_attr( $thumbnail ),
                     'width' => esc_attr( $thumbnail_width ),
-                    'style' => 'width: 80px !important;',
                 ),
             );
 


### PR DESCRIPTION
fixes https://github.com/Strategy11/awpcp/issues/3178

This PR adds width to the style property of the excerpt thumbnail to prevent an issue that occurred after WP 6.7