### PR TITLE
Prevent PHP notices if ad dates are not set

### DIFF
--- a/frontend/class-awpcp-meta.php
+++ b/frontend/class-awpcp-meta.php
@@ -246,12 +246,20 @@ class AWPCP_Meta {
             $format = get_option( 'date_format' );
         }
 
+        if ( empty( $this->properties['published-time'] ) ) {
+            return $the_date;
+        }
+
         return mysql2date( $format, $this->properties['published-time'] );
     }
 
     public function get_the_modified_date( $the_date, $format ) {
         if ( ! $format ) {
             $format = get_option( 'date_format' );
+        }
+
+        if ( empty( $this->properties['modified-time'] ) ) {
+            return $the_date;
         }
 
         return mysql2date( $format, $this->properties['modified-time'] );


### PR DESCRIPTION
fixes https://github.com/Strategy11/awpcp/issues/3174

This PR prevents calling on null notices for OG meta date rendering methods.