### PR TITLE
Remove stray </span> tag from search widget title

### DIFF
--- a/frontend/widget-search.php
+++ b/frontend/widget-search.php
@@ -109,7 +109,7 @@ class AWPCP_Search_Widget extends WP_Widget {
         if ( !empty( $instance['subtitle'] ) ) {
             $title = $instance['title'] . '<br/><span class="widgetstitle">' . esc_html( $instance['subtitle'] ) . '</span>';
         } else {
-            $title = $instance['title'] . '</span>';
+            $title = $instance['title'];
         }
 
         echo '<div class="awpcp-search-listings-widget">';


### PR DESCRIPTION
When no subtitle is set in the search ads widget, the else branch appended a closing `</span>` without a matching opening tag, causing it to render as visible text in the widget title.

Fixes https://github.com/Strategy11/awpcp/issues/3182