### PR TITLE
Add WebP image support

### DIFF
--- a/includes/media/class-file-types.php
+++ b/includes/media/class-file-types.php
@@ -44,7 +44,7 @@ class AWPCP_FileTypes {
                     'mime_types' => array( 'image/gif' ),
                 ),
                 'webp' => array(
-                    'name'       => 'WebP',
+                    'name'       => 'WEBP',
                     'extensions' => array( 'webp' ),
                     'mime_types' => array( 'image/webp' ),
                 ),

--- a/includes/media/class-file-types.php
+++ b/includes/media/class-file-types.php
@@ -43,6 +43,11 @@ class AWPCP_FileTypes {
                     'extensions' => array( 'gif' ),
                     'mime_types' => array( 'image/gif' ),
                 ),
+                'webp' => array(
+                    'name'       => 'WebP',
+                    'extensions' => array( 'webp' ),
+                    'mime_types' => array( 'image/webp' ),
+                ),
             ),
         );
     }


### PR DESCRIPTION
Register webp extension and image/webp mime type in the default image file types so users can upload WebP images to listings.

Fixes https://github.com/Strategy11/awpcp/issues/3169