### PR TITLE
Fix URL encoding in plain text emails

### DIFF
--- a/frontend/templates/email-abort-payment-admin.tpl.php
+++ b/frontend/templates/email-abort-payment-admin.tpl.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <?php
 echo "\t";
-echo wp_kses_post( $message );
+echo awpcp_esc_plaintext( $message );
 ?>
 
 <?php if ($user): ?>

--- a/frontend/templates/email-abort-payment-user.tpl.php
+++ b/frontend/templates/email-abort-payment-user.tpl.php
@@ -4,13 +4,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // emails are sent in plain text, trailing whitespace are required for proper formatting ?>
-<?php echo wp_kses_post( get_awpcp_option( 'paymentabortedbodymessage' ) ); ?>
+<?php
+echo awpcp_esc_plaintext( awpcp_get_option( 'paymentabortedbodymessage' ) ); ?>
 
 <?php esc_html_e( 'Additional Details', 'another-wordpress-classifieds-plugin' ); ?>
 
 <?php
 echo "\t";
-echo wp_kses_post( $message );
+echo awpcp_esc_plaintext( $message );
 ?>
 
 <?php if ($transaction): ?>

--- a/frontend/templates/email-ad-awaiting-approval-admin.tpl.php
+++ b/frontend/templates/email-ad-awaiting-approval-admin.tpl.php
@@ -5,7 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 foreach ($messages as $message): ?>
-<?php echo wp_kses_post( $message ); ?>
+<?php
+echo awpcp_esc_plaintext( $message ); ?>
 
 <?php endforeach; ?>
 

--- a/frontend/templates/email-ad-renewed-success-admin.tpl.php
+++ b/frontend/templates/email-ad-renewed-success-admin.tpl.php
@@ -9,4 +9,4 @@ esc_html_e( 'An ad has been renewed. A copy of the details sent to the customer 
 ?>
 
 <?php
-echo wp_kses_post( $body );
+echo awpcp_esc_plaintext( $body );

--- a/frontend/templates/email-ad-renewed-success-user.tpl.php
+++ b/frontend/templates/email-ad-renewed-success-user.tpl.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // emails are sent in plain text, blank lines in templates are required ?>
-<?php echo wp_kses_post( $introduction ); ?>
+<?php echo awpcp_esc_plaintext( $introduction ); ?>
 
 
 <?php esc_html_e( 'Listing Title', 'another-wordpress-classifieds-plugin' ); ?>: <?php echo esc_html( $listing_title ); ?>
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <?php esc_html_e( 'Listing Edit Email', 'another-wordpress-classifieds-plugin' ); ?>: <?php echo esc_html( $contact_email ); ?>
 
-<?php if ( get_awpcp_option( 'include-ad-access-key' ) ): ?>
+<?php if ( awpcp_get_option( 'include-ad-access-key' ) ): ?>
 <?php esc_html_e( 'Listing Edit Key', 'another-wordpress-classifieds-plugin' ); ?>: <?php echo esc_html( $access_key ); ?>
 <?php endif; ?>
 

--- a/frontend/templates/email-ad-updated-user.tpl.php
+++ b/frontend/templates/email-ad-updated-user.tpl.php
@@ -6,7 +6,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 esc_html_e( 'Your Ad has been successfully updated. Ad information is shown below.', 'another-wordpress-classifieds-plugin') ?>
 
 <?php if (!empty($message)): ?>
-<?php echo wp_kses_post( $message ); ?>
+<?php
+echo awpcp_esc_plaintext( $message ); ?>
 <?php endif ?>
 
 <?php esc_html_e( 'Ad Information', 'another-wordpress-classifieds-plugin' ); ?>
@@ -15,7 +16,7 @@ esc_html_e( 'Your Ad has been successfully updated. Ad information is shown belo
 <?php esc_html_e( 'Listing URL', 'another-wordpress-classifieds-plugin' ); ?>: <?php echo esc_url_raw( get_permalink( $ad->ID ) ); ?>
 <?php esc_html_e( 'Listing ID', 'another-wordpress-classifieds-plugin' ); ?>: <?php echo esc_html( $ad->ID ); ?>
 <?php esc_html_e( 'Listing Edit Email', 'another-wordpress-classifieds-plugin' ); ?>: <?php echo esc_html( $contact_email ); ?>
-<?php if ( get_awpcp_option( 'include-ad-access-key' ) ): ?>
+<?php if ( awpcp_get_option( 'include-ad-access-key' ) ): ?>
 <?php esc_html_e( 'Listing Edit Key', 'another-wordpress-classifieds-plugin' ); ?>: <?php echo esc_html( $access_key ); ?>
 <?php endif; ?>
 

--- a/frontend/templates/email-place-ad-success-admin.tpl.php
+++ b/frontend/templates/email-place-ad-success-admin.tpl.php
@@ -9,4 +9,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php printf( esc_html( $message ), esc_url_raw( $url ) ); ?>
 
 <?php
-echo wp_kses_post( $content );
+echo awpcp_esc_plaintext( $content );

--- a/frontend/templates/email-place-ad-success-user.tpl.php
+++ b/frontend/templates/email-place-ad-success-user.tpl.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-echo wp_kses_post( get_awpcp_option( 'listingaddedbody' ) ); ?>
+echo awpcp_esc_plaintext( awpcp_get_option( 'listingaddedbody' ) ); ?>
 
 <?php esc_html_e( 'Listing Title', 'another-wordpress-classifieds-plugin' ); ?>: <?php echo esc_html( $listing_title ); ?>
 
@@ -45,7 +45,8 @@ echo wp_kses_post( get_awpcp_option( 'listingaddedbody' ) ); ?>
 <?php if (!empty($message)): ?>
 <?php esc_html_e( 'Additional Details', 'another-wordpress-classifieds-plugin' ); ?>
 
-<?php echo wp_kses_post( $message ); ?>
+<?php
+echo awpcp_esc_plaintext( $message ); ?>
 
 <?php endif ?>
 <?php

--- a/frontend/templates/email-send-all-ad-access-keys.tpl.php
+++ b/frontend/templates/email-send-all-ad-access-keys.tpl.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-echo wp_kses_post( $introduction );
+echo awpcp_esc_plaintext( $introduction );
 ?>:
 
 <?php esc_html_e( 'Total ads found sharing your email address', 'another-wordpress-classifieds-plugin' ); ?>: <?php echo esc_html( count( $ads ) ); ?>

--- a/functions.php
+++ b/functions.php
@@ -205,6 +205,18 @@ function awpcp_esc_textarea($text) {
 }
 
 /**
+ * Escape a string for use in plain text email output.
+ *
+ * @since x.x
+ *
+ * @param string $text Text to escape.
+ * @return string
+ */
+function awpcp_esc_plaintext( $text ) {
+    return wp_strip_all_tags( (string) $text );
+}
+
+/**
  * @since 3.3
  */
 function awpcp_apply_function_deep( $function, $value ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -90,6 +90,7 @@
 			<property name="customAutoEscapedFunctions" type="array">
                 <element value="awpcp_esc_attr" />
                 <element value="awpcp_esc_textarea" />
+                <element value="awpcp_esc_plaintext" />
                 <element value="wp_nonce_url" />
                 <element value="awpcp_print_error" />
                 <element value="awpcp_print_message" />


### PR DESCRIPTION
Replace wp_kses_post() with a new awpcp_esc_plaintext() helper that
strips HTML tags without encoding entities. This prevents ampersands
in URLs from being converted to &amp; in plain text emails.

Also replaces deprecated get_awpcp_option() calls with awpcp_get_option()
in the affected templates.

Fixes https://github.com/Strategy11/awpcp/issues/3199