### PR TITLE
Improve mobile layout for listing thumbnails

### DIFF
--- a/resources/less/frontend/modules/listing-excerpt.less
+++ b/resources/less/frontend/modules/listing-excerpt.less
@@ -9,7 +9,7 @@
 .awpcp-listing-excerpt-thumbnail {
     box-sizing: border-box;
     text-align: center;
-    width: 100%;
+    width: fit-content;
 }
 .awpcp-listing-primary-image-listing-link {
     display: block;


### PR DESCRIPTION
Change the listing excerpt thumbnail container from width: 100% to
width: fit-content so images don't force the title to wrap below on
narrow (mobile) viewports.

Fixes https://github.com/Strategy11/awpcp/issues/3137