### PR TITLE
Fix AWPCPBROWSECATS to show categories list

### DIFF
--- a/frontend/class-categories-switcher.php
+++ b/frontend/class-categories-switcher.php
@@ -38,7 +38,7 @@ class AWPCP_Categories_Switcher {
      * @param array $params     An array of parameters for the Categories Switcher component.
      */
     public function render( $params = array() ) {
-        if ( $this->query->is_browse_listings_page() || $this->query->is_browse_categories_page() ) {
+        if ( $this->query->is_browse_listings_page() ) {
             $action_url = awpcp_current_url();
         } else {
             $action_url = awpcp_get_browse_categories_page_url();

--- a/frontend/class-query.php
+++ b/frontend/class-query.php
@@ -71,7 +71,7 @@ class AWPCP_Query {
     }
 
     public function is_browse_categories_page() {
-        return $this->is_browse_listings_page();
+        return $this->is_page_that_has_shortcode( 'AWPCPBROWSECATS' );
     }
 
     public function is_renew_listing_page() {

--- a/frontend/class-url-backwards-compatibility-redirection-helper.php
+++ b/frontend/class-url-backwards-compatibility-redirection-helper.php
@@ -122,7 +122,7 @@ class AWPCP_URL_Backwards_Compatibility_Redirection_Helper {
             return;
         }
 
-        if ( $this->query->is_browse_listings_page() || $this->query->is_browse_categories_page() ) {
+        if ( $this->query->is_browse_listings_page() ) {
             $this->maybe_redirect_browse_listings_request();
             return;
         }

--- a/frontend/shortcode.php
+++ b/frontend/shortcode.php
@@ -64,7 +64,7 @@ class AWPCP_Pages {
         add_shortcode( 'AWPCPPAYMENTTHANKYOU', array( $this, 'noop' ) );
         add_shortcode( 'AWPCPCANCELPAYMENT', array( $this, 'noop' ) );
 
-        add_shortcode( 'AWPCPBROWSECATS', array( $this->browse_ads, 'dispatch' ) );
+        add_shortcode( 'AWPCPBROWSECATS', array( $this, 'browse_categories' ) );
         add_shortcode( 'AWPCPBROWSEADS', array( $this->browse_ads, 'dispatch' ) );
 
         add_shortcode( 'AWPCPSHOWAD', array( $this, 'show_ad' ) );
@@ -139,6 +139,25 @@ class AWPCP_Pages {
         }
 
         return $this->output['search-ads'];
+    }
+
+    /**
+     * Renders the View Categories list (same UI as main-page layout=2).
+     *
+     * Previously aliased to Browse Ads for backwards compatibility.
+     *
+     * @since x.x
+     *
+     * @return string
+     */
+    public function browse_categories() {
+        if ( ! isset( $this->output['browse-categories'] ) ) {
+            awpcp_enqueue_main_script();
+
+            $this->output['browse-categories'] = awpcp_display_the_classifieds_page_body( '' );
+        }
+
+        return $this->output['browse-categories'];
     }
 
     public function reply_to_ad() {
@@ -492,7 +511,7 @@ function awpcp_get_menu_items( $params ) {
     }
 
     if ( $show_browse_ads_item ) {
-        if ( awpcp_is_browse_listings_page() || awpcp_is_browse_categories_page() ) {
+        if ( awpcp_is_browse_listings_page() ) {
             if ( get_awpcp_option( 'main_page_display' ) ) {
                 $browse_cats_url = awpcp_get_view_categories_url();
             } else {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/awpcp/issues/3187

[AWPCPBROWSECATS] now renders the View Categories list instead of aliasing Browse Ads.
Page detection and menu/switcher/redirect callers were updated to match.