### PR TITLE
Show Terms of Service for admins on Place Ad

### DIFF
--- a/frontend/page-place-ad.php
+++ b/frontend/page-place-ad.php
@@ -889,7 +889,7 @@ class AWPCP_Place_Ad_Page extends AWPCP_Page {
         $ui['allow-regions-modification']   = $is_moderator || !$edit || get_awpcp_option( 'allow-regions-modification' );
         $ui['price-field']                  = get_awpcp_option('displaypricefield') == 1;
         $ui['extra-fields']                 = $hasextrafieldsmodule && function_exists( 'awpcp_extra_fields_module' );
-        $ui['terms-of-service']             = !$edit && !$is_moderator && get_awpcp_option('requiredtos');
+        $ui['terms-of-service']             = ! $edit && get_awpcp_option( 'requiredtos' );
         $ui['captcha']                      = !$edit && !is_admin() && ( get_awpcp_option( 'captcha-enabled-in-place-listing-form' ) == 1 );
 
         $hidden['step']        = 'save-details';
@@ -1159,8 +1159,8 @@ class AWPCP_Place_Ad_Page extends AWPCP_Page {
         }
 
         // Terms of service required and accepted?
-        if (!$edit && !$is_moderator && get_awpcp_option('requiredtos') && empty($data['terms-of-service'])) {
-            $errors['terms-of-service'] = __("You did not accept the terms of service", 'another-wordpress-classifieds-plugin');
+        if ( ! $edit && get_awpcp_option( 'requiredtos' ) && empty( $data['terms-of-service'] ) ) {
+            $errors['terms-of-service'] = __( 'You did not accept the terms of service', 'another-wordpress-classifieds-plugin' );
         }
 
         if ( !$edit && !is_admin() && get_awpcp_option( 'captcha-enabled-in-place-listing-form' ) ) {

--- a/includes/class-container-configuration.php
+++ b/includes/class-container-configuration.php
@@ -106,7 +106,6 @@ class AWPCP_ContainerConfiguration implements AWPCP_ContainerConfigurationInterf
         $container['FormFieldsValidator'] = $container->service( function( $container ) {
             return new AWPCP_FormFieldsValidator(
                 $container['ListingAuthorization'],
-                $container['RolesAndCapabilities'],
                 $container['Settings']
             );
         } );

--- a/includes/constructor-functions.php
+++ b/includes/constructor-functions.php
@@ -194,7 +194,6 @@ function awpcp_terms_of_service_form_field( $slug ) {
 
     return new AWPCP_TermsOfServiceFormField(
         $slug,
-        $container['RolesAndCapabilities'],
         $container['Settings'],
         $container['TemplateRenderer']
     );

--- a/includes/form-fields/class-form-fields-validator.php
+++ b/includes/form-fields/class-form-fields-validator.php
@@ -18,11 +18,6 @@ class AWPCP_FormFieldsValidator {
     private $authorization;
 
     /**
-     * @var AWPCP_RolesAndCapabilities
-     */
-    private $roles;
-
-    /**
      * @var object
      */
     private $settings;
@@ -30,13 +25,11 @@ class AWPCP_FormFieldsValidator {
     /**
      * @since 4.0.0
      *
-     * @param object $authorization     An instance of Listing Authorization.
-     * @param object $roles             An instance of Roles and Capabilities.
-     * @param object $settings          An instance of Settings API.
+     * @param object $authorization An instance of Listing Authorization.
+     * @param object $settings      An instance of Settings API.
      */
-    public function __construct( $authorization, $roles, $settings ) {
+    public function __construct( $authorization, $settings ) {
         $this->authorization = $authorization;
-        $this->roles         = $roles;
         $this->settings      = $settings;
     }
 

--- a/includes/form-fields/class-form-fields-validator.php
+++ b/includes/form-fields/class-form-fields-validator.php
@@ -136,7 +136,7 @@ class AWPCP_FormFieldsValidator {
             }
         }
 
-        if ( $this->settings->get_option( 'requiredtos' ) && ! $this->roles->current_user_is_moderator() ) {
+        if ( $this->settings->get_option( 'requiredtos' ) ) {
             if ( $data['terms_of_service'] !== 'accepted' ) {
                 $errors['terms_of_service'] = __( 'Please read and accept the Terms of Service.', 'another-wordpress-classifieds-plugin' );
             }

--- a/includes/form-fields/class-terms-of-service-form-field.php
+++ b/includes/form-fields/class-terms-of-service-form-field.php
@@ -67,10 +67,6 @@ class AWPCP_TermsOfServiceFormField extends AWPCP_FormField {
             return false;
         }
 
-        if ( $this->roles->current_user_is_moderator() ) {
-            return false;
-        }
-
         return true;
     }
 

--- a/includes/form-fields/class-terms-of-service-form-field.php
+++ b/includes/form-fields/class-terms-of-service-form-field.php
@@ -15,11 +15,6 @@ class AWPCP_TermsOfServiceFormField extends AWPCP_FormField {
     private $template = 'frontend/form-fields/terms-of-service-form-field.tpl.php';
 
     /**
-     * @var AWPCP_RolesAndCapabilities
-     */
-    private $roles;
-
-    /**
      * @var AWPCP_Settings_API
      */
     private $settings;
@@ -32,10 +27,9 @@ class AWPCP_TermsOfServiceFormField extends AWPCP_FormField {
     /**
      * @since 4.0.2
      */
-    public function __construct( $slug, $roles, $settings, $template_renderer ) {
+    public function __construct( $slug, $settings, $template_renderer ) {
         parent::__construct( $slug );
 
-        $this->roles             = $roles;
         $this->settings          = $settings;
         $this->template_renderer = $template_renderer;
     }

--- a/tests/suite/form-fields/test-form-fields-validator.php
+++ b/tests/suite/form-fields/test-form-fields-validator.php
@@ -14,11 +14,6 @@ class AWPCP_FormFieldsDataValidatorTest extends AWPCP_UnitTestCase {
     /**
      * @var mixed
      */
-    public $roles;
-
-    /**
-     * @var mixed
-     */
     public $data;
 
     /**
@@ -36,8 +31,6 @@ class AWPCP_FormFieldsDataValidatorTest extends AWPCP_UnitTestCase {
      */
     public function setUp(): void {
         parent::setUp();
-
-        $this->roles = Mockery::mock( 'AWPCP_RolesAndCapabilities' );
 
         $this->data = array(
             'post_fields'      => array(
@@ -95,8 +88,6 @@ class AWPCP_FormFieldsDataValidatorTest extends AWPCP_UnitTestCase {
         $this->authorization->shouldReceive( 'is_current_user_allowed_to_edit_listing_end_date' )
             ->andReturn( true );
 
-        $this->roles->shouldReceive( 'current_user_is_moderator' )->andReturn( false );
-
         $this->settings->shouldReceive( 'get_option' )->andReturnUsing(
             function( $name ) {
                 $options = array(
@@ -126,7 +117,6 @@ class AWPCP_FormFieldsDataValidatorTest extends AWPCP_UnitTestCase {
     private function get_test_subject() {
         return new AWPCP_FormFieldsValidator(
             $this->authorization,
-            $this->roles,
             $this->settings
         );
     }

--- a/tests/suite/form-fields/test-terms-of-service-form-field.php
+++ b/tests/suite/form-fields/test-terms-of-service-form-field.php
@@ -71,7 +71,7 @@ class AWPCP_TermsOfServiceFormFieldTest extends AWPCP_UnitTestCase {
                 'is_moderator'    => false,
             ],
             [
-                'expected_result' => false,
+                'expected_result' => true,
                 'require_tos'     => true,
                 'is_moderator'    => true,
             ],

--- a/tests/suite/form-fields/test-terms-of-service-form-field.php
+++ b/tests/suite/form-fields/test-terms-of-service-form-field.php
@@ -11,11 +11,6 @@ class AWPCP_TermsOfServiceFormFieldTest extends AWPCP_UnitTestCase {
     /**
      * @var mixed
      */
-    public $roles;
-
-    /**
-     * @var mixed
-     */
     public $settings;
 
     /**
@@ -29,7 +24,6 @@ class AWPCP_TermsOfServiceFormFieldTest extends AWPCP_UnitTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->roles             = Mockery::mock( 'AWPCP_RolesAndCapabilities' );
         $this->settings          = Mockery::mock( 'AWPCP_Settings' );
         $this->template_renderer = null;
     }
@@ -39,7 +33,7 @@ class AWPCP_TermsOfServiceFormFieldTest extends AWPCP_UnitTestCase {
      *
      * @dataProvider is_allowed_in_context_data_provider
      */
-    public function test_is_allowed_in_context( $expected_result, $require_tos, $is_moderator, $context = [] ) {
+    public function test_is_allowed_in_context( $expected_result, $require_tos, $context = [] ) {
         $default_context = [
             'action' => 'not-search',
         ];
@@ -49,9 +43,6 @@ class AWPCP_TermsOfServiceFormFieldTest extends AWPCP_UnitTestCase {
         $this->settings->shouldReceive( 'get_option' )
             ->with( 'requiredtos' )
             ->andReturn( $require_tos );
-
-        $this->roles->shouldReceive( 'current_user_is_moderator' )
-            ->andReturn( $is_moderator );
 
         // Execution.
         $is_allowed = $this->get_test_subject()->is_allowed_in_context( $context );
@@ -68,22 +59,14 @@ class AWPCP_TermsOfServiceFormFieldTest extends AWPCP_UnitTestCase {
             [
                 'expected_result' => true,
                 'require_tos'     => true,
-                'is_moderator'    => false,
-            ],
-            [
-                'expected_result' => true,
-                'require_tos'     => true,
-                'is_moderator'    => true,
             ],
             [
                 'expected_result' => false,
                 'require_tos'     => false,
-                'is_moderator'    => false,
             ],
             [
                 'expected_result' => false,
                 'require_tos'     => true,
-                'is_moderator'    => false,
                 'context'         => [ 'action' => 'search' ],
             ],
         ];
@@ -95,7 +78,6 @@ class AWPCP_TermsOfServiceFormFieldTest extends AWPCP_UnitTestCase {
     private function get_test_subject() {
         return new AWPCP_TermsOfServiceFormField(
             'slug',
-            $this->roles,
             $this->settings,
             $this->template_renderer
         );


### PR DESCRIPTION
Fixes Strategy11/awpcp#3131
Remove the moderator bypass so Place Ad shows and requires Terms of Service for admins and moderators when the setting is enabled.