### PR TITLE
Redirect User Listings to custom login URL

### DIFF
--- a/frontend/class-query.php
+++ b/frontend/class-query.php
@@ -50,6 +50,13 @@ class AWPCP_Query {
         return $this->is_page_that_has_shortcode( 'AWPCPREPLYTOAD' );
     }
 
+    /**
+     * @since x.x
+     */
+    public function is_user_listings_page() {
+        return $this->is_page_that_has_shortcode( 'AWPCPUSERLISTINGS' );
+    }
+
     public function is_browse_listings_page() {
         return $this->is_page_that_has_shortcode( 'AWPCPBROWSEADS' );
     }

--- a/includes/class-authentication-redirection-handler.php
+++ b/includes/class-authentication-redirection-handler.php
@@ -32,6 +32,8 @@ class AWPCP_Authentication_Redirection_Handler {
             $page_requires_authentication = $this->post_listing_page_requires_authentication();
         } elseif ( $this->query->is_reply_to_listing_page() ) {
             $page_requires_authentication = $this->reply_to_listing_page_requires_autentication();
+        } elseif ( $this->query->is_user_listings_page() ) {
+            $page_requires_authentication = $this->user_listings_page_requires_authentication();
         } else {
             $page_requires_authentication = false;
         }
@@ -47,6 +49,13 @@ class AWPCP_Authentication_Redirection_Handler {
 
     private function reply_to_listing_page_requires_autentication() {
         return $this->settings->get_option( 'reply-to-ad-requires-registration' );
+    }
+
+    /**
+     * @since x.x
+     */
+    private function user_listings_page_requires_authentication() {
+        return $this->settings->get_option( 'requireuserregistration' );
     }
 
     private function redirect_to_login_page( $login_url ) {


### PR DESCRIPTION
Fixes [#3170](https://github.com/Strategy11/awpcp/issues/3170)

User Listings now redirects logged-out users to the custom login URL when Place Ad requires registration, matching Place Ad and Reply behavior.